### PR TITLE
feat(lark): support enterprise_email field as email fallback

### DIFF
--- a/idp/lark.go
+++ b/idp/lark.go
@@ -135,6 +135,7 @@ func (idp *LarkIdProvider) GetToken(code string) (*oauth2.Token, error) {
         "open_id": "ou-caecc734c2e3328a62489fe0648c4b98779515d3",
         "union_id": "on-d89jhsdhjsajkda7828enjdj328ydhhw3u43yjhdj",
         "email": "zhangsan@feishu.cn",
+        "enterprise_email": "zhangsan@company.com",
         "user_id": "5d9bdxxx",
         "mobile": "+86130002883xx",
         "tenant_key": "736588c92lxf175d",
@@ -160,6 +161,7 @@ type LarkUserInfo struct {
 		OpenId           string `json:"open_id"`
 		UnionId          string `json:"union_id"`
 		Email            string `json:"email"`
+		EnterpriseEmail  string `json:"enterprise_email"`
 		UserId           string `json:"user_id"`
 		Mobile           string `json:"mobile"`
 		TenantKey        string `json:"tenant_key"`
@@ -168,7 +170,6 @@ type LarkUserInfo struct {
 	} `json:"data"`
 }
 
-// GetUserInfo use LarkAccessToken gotten before return LinkedInUserInf
 // GetUserInfo use LarkAccessToken gotten before return LinkedInUserInfo
 // get more detail via: https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context
 func (idp *LarkIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
@@ -207,6 +208,12 @@ func (idp *LarkIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
 		return nil, err
 	}
 
+	// Use enterprise_email as fallback when email is empty
+	email := larkUserInfo.Data.Email
+	if email == "" {
+		email = larkUserInfo.Data.EnterpriseEmail
+	}
+
 	var phoneNumber string
 	var countryCode string
 	if len(larkUserInfo.Data.Mobile) != 0 {
@@ -222,7 +229,7 @@ func (idp *LarkIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
 		Id:          larkUserInfo.Data.OpenId,
 		DisplayName: larkUserInfo.Data.Name,
 		Username:    larkUserInfo.Data.UserId,
-		Email:       larkUserInfo.Data.Email,
+		Email:       email,
 		AvatarUrl:   larkUserInfo.Data.AvatarUrl,
 		Phone:       phoneNumber,
 		CountryCode: countryCode,


### PR DESCRIPTION
Add enterprise_email field support to Lark provider to handle enterprise users where primary email is stored in enterprise_email instead of email field.

Fixes #4119